### PR TITLE
Override default target platform to iOS

### DIFF
--- a/tv/tv_app/lib/main.dart
+++ b/tv/tv_app/lib/main.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
-import "dart:io";
 import "monitor_widget.dart";
+import 'package:flutter/foundation.dart' show debugDefaultTargetPlatformOverride;
 
 void main()
 {
+  debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
 	runApp(new MonitorApp());
 }
 


### PR DESCRIPTION
Following [flutter-desktop-embedding README](https://github.com/google/flutter-desktop-embedding/blob/master/Flutter-Requirements.md#target-platform-override), will need to override the target platform for the application to one of the supported values in order to avoid 'Unknown platform' exceptions.